### PR TITLE
Only load js mock file

### DIFF
--- a/boilerplates/app/proxy.config.js
+++ b/boilerplates/app/proxy.config.js
@@ -4,7 +4,9 @@ const mock = {};
 
 require('fs').readdirSync(require('path').join(__dirname + '/mock'))
   .forEach(function (file) {
-    Object.assign(mock, require('./mock/' + file));
+    if (/\.js$/.test(file)) {
+      Object.assign(mock, require('./mock/' + file));
+    }
   });
 
 module.exports = mock;


### PR DESCRIPTION
现在 Vim 创建的备份文件 *.swp 也会被加载进来，导致 `proxy: proxy.config.js parse error`