### PR TITLE
Add support for yarn. Yarn as first choice if it exists.

### DIFF
--- a/bin/dva-new
+++ b/bin/dva-new
@@ -10,7 +10,7 @@ const error = chalk.red;
 program
   .usage('[options] appName')
   .option('--demo', 'Generate a dead simple project for quick prototype')
-  .option('--no-install', 'Disable npm install after files created')
+  .option('--no-install', 'Disable yarn/npm install after files created')
   .parse(process.argv);
 
 if (!program.args[0]) {

--- a/src/init.js
+++ b/src/init.js
@@ -39,7 +39,7 @@ function init({ demo, install }) {
       info('rename', 'gitignore -> .gitignore');
       renameSync(join(dest, 'gitignore'), join(dest, '.gitignore'));
       if (install) {
-        info('run', 'npm install');
+        info('run', 'yarn/npm install');
         require('./install')(printSuccess);
       } else {
         printSuccess();
@@ -52,13 +52,13 @@ function init({ demo, install }) {
 Success! Created ${projectName} at ${dest}.
 
 Inside that directory, you can run several commands:
-  * npm start: Starts the development server.
-  * npm run build: Bundles the app into dist for production.
-  * npm test: Run test.
+  * yarn/npm start: Starts the development server.
+  * yarn/npm run build: Bundles the app into dist for production.
+  * yarn/npm test: Run test.
 
 We suggest that you begin by typing:
   cd ${dest}
-  npm start
+  yarn/npm start
 
 Happy hacking!`);
   }

--- a/src/install.js
+++ b/src/install.js
@@ -13,25 +13,54 @@ function runCmd(cmd, args, fn) {
   });
 }
 
-function findNpm() {
-  var npms = process.platform === 'win32' ? ['tnpm.cmd', 'cnpm.cmd', 'npm.cmd'] : ['tnpm', 'cnpm', 'npm'];
-  for (var i = 0; i < npms.length; i++) {
+function findExe(exes) {
+  for (var i = 0; i < exes.length; i++) {
     try {
-      which.sync(npms[i]);
-      console.log('use npm: ' + npms[i]);
-      return npms[i];
+      which.sync(exes[i]);
+      console.log('use pkg manager: ' + exes[i]);
+
+      return exes[i];
     } catch (e) {
     }
   }
-  throw new Error('please install npm');
+
+  return null;
+}
+
+function findYarn() {
+  var yarnExes = process.platform === 'win32' ? ['yarn.cmd', 'yarnpkg.cmd'] : ['yarn', 'yarnpkg'];
+
+  return findExe(yarnExes);
+}
+
+function findNpm() {
+  var npmExes = process.platform === 'win32' ? ['tnpm.cmd', 'cnpm.cmd', 'npm.cmd'] : ['tnpm', 'cnpm', 'npm'];
+
+  return findExe(npmExes);
 }
 
 export default function (done) {
-  const npm = findNpm();
-  runCmd(which.sync(npm), ['install'], function () {
-    runCmd(which.sync(npm), ['install', 'dva', '--save'], function () {
-      console.log(npm + ' install end');
-      done();
+  const yarn = findYarn();
+
+  if (yarn) {
+    runCmd(which.sync(yarn), ['install'], function () {
+      runCmd(which.sync(yarn), ['add', 'dva'], function () {
+        console.log(yarn + ' install end');
+        done();
+      });
     });
-  });
+  } else {
+    const npm = findNpm();
+
+    if (!npm) {
+      throw new Error('please install yarn or npm');
+    }
+
+    runCmd(which.sync(npm), ['install'], function () {
+      runCmd(which.sync(npm), ['install', 'dva', '--save'], function () {
+        console.log(npm + ' install end');
+        done();
+      });
+    });
+  }
 };


### PR DESCRIPTION
It's better to have yarn as the default package manager, which speeds up the installation.