### PR TITLE
Remove script in templates

### DIFF
--- a/boilerplates/app/src/index.ejs
+++ b/boilerplates/app/src/index.ejs
@@ -10,7 +10,5 @@
 
 <div id="root"></div>
 
-<script src="/index.js"></script>
-
 </body>
 </html>

--- a/boilerplates/demo/src/index.ejs
+++ b/boilerplates/demo/src/index.ejs
@@ -10,7 +10,5 @@
 
 <div id="root"></div>
 
-<script src="index.js"></script>
-
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dva-cli",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "The dva command line utility.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Since roadhog 1.0.0, scripts are injected during build. Explicitly loading scripts is not needed.