### PR TITLE
Remove the redundant script tag

### DIFF
--- a/boilerplates/app/src/index.ejs
+++ b/boilerplates/app/src/index.ejs
@@ -7,10 +7,6 @@
   <link rel="stylesheet" href="/index.css" />
 </head>
 <body>
-
-<div id="root"></div>
-
-<script src="/index.js"></script>
-
+  <div id="root"></div>
 </body>
 </html>

--- a/boilerplates/demo/src/index.ejs
+++ b/boilerplates/demo/src/index.ejs
@@ -7,10 +7,6 @@
   <link rel="stylesheet" href="index.css" />
 </head>
 <body>
-
-<div id="root"></div>
-
-<script src="index.js"></script>
-
+  <div id="root"></div>
 </body>
 </html>


### PR DESCRIPTION
现在依赖的 roadhog 版本存在`index.ejs`，然后会使用`html-webpack-plugin`引入打包后的 js 文件，而且`html-webpack-plugin`的配置参数有`inject: true`，这样就导致重复引入 js，然后浏览器控制台一直报错（不影响应用的功能），具体描述你可以看[这里](https://github.com/facebook/react/issues/6472#issuecomment-244508603)。不是一定会报错，可能在某些使用了某些标签情况下才会，然后去掉重复引入就好了。