### PR TITLE
remove <link index.css>, avoid warning

### DIFF
--- a/boilerplates/app/src/index.ejs
+++ b/boilerplates/app/src/index.ejs
@@ -4,7 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Dva Demo</title>
-  <link rel="stylesheet" href="/index.css" />
 </head>
 <body>
   <div id="root"></div>


### PR DESCRIPTION
`<link rel="stylesheet" href="/index.css" />` is superfluous