### PR TITLE
Upgrade "babel-preset-es2015" to "babel-preset-env"

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,14 +33,14 @@
     "babel-cli": "^6.10.1",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-runtime": "^6.9.0",
-    "babel-preset-es2015": "^6.9.0",
+    "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "~6.5.0",
     "babel-runtime": "^6.9.2"
   },
   "babel": {
     "presets": [
-      "es2015",
+      "env",
       "react",
       "stage-0"
     ],


### PR DESCRIPTION
This PR upgrades the `babel-preset-es2015` to `babel-preset-env`, as [recommended by the Babbel team](http://babeljs.io/env).
