### PR TITLE
fix: history@4.9 which is using @babel/runtime@7

### DIFF
--- a/boilerplates/app/package.json
+++ b/boilerplates/app/package.json
@@ -21,6 +21,6 @@
     "eslint-plugin-react": "^7.1.0",
     "husky": "^0.12.0",
     "redbox-react": "^1.4.3",
-    "roadhog": "^2.0.0"
+    "roadhog": "^2.5.0-beta.4"
   }
 }


### PR DESCRIPTION
Close https://github.com/dvajs/dva/issues/2032
